### PR TITLE
Make FindExe function ignore directories we aren't allowed to access

### DIFF
--- a/Gu.Wpf.UiAutomation/Application.cs
+++ b/Gu.Wpf.UiAutomation/Application.cs
@@ -9,6 +9,7 @@ namespace Gu.Wpf.UiAutomation
     using System.Linq;
     using System.Reflection;
     using System.Windows.Automation;
+    using Gu.Wpf.UiAutomation.Internals;
     using Gu.Wpf.UiAutomation.Logging;
     using Gu.Wpf.UiAutomation.WindowsAPI;
 
@@ -624,7 +625,7 @@ namespace Gu.Wpf.UiAutomation
                     return fileName;
                 }
 
-                var match = Directory.EnumerateFiles(Directory.GetCurrentDirectory(), fileName, SearchOption.AllDirectories)
+                var match = SafeDirectoryEnumeration.EnumerateFilesOpportunistic(Directory.GetCurrentDirectory(), fileName, SearchOption.AllDirectories)
                                      .FirstOrDefault();
                 if (match != null)
                 {

--- a/Gu.Wpf.UiAutomation/Internals/SafeDirectoryEnumeration.cs
+++ b/Gu.Wpf.UiAutomation/Internals/SafeDirectoryEnumeration.cs
@@ -1,0 +1,51 @@
+namespace Gu.Wpf.UiAutomation.Internals
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Security;
+
+    internal static class SafeDirectoryEnumeration
+    {
+        public static IEnumerable<string> EnumerateFilesOpportunistic(string path, string searchPattern, SearchOption searchOption)
+        {
+            if (searchOption == SearchOption.AllDirectories)
+            {
+                IEnumerable<string> subdirEntries;
+                try
+                {
+                    subdirEntries = Directory.EnumerateDirectories(path);
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    yield break;
+                }
+                catch (SecurityException)
+                {
+                    yield break;
+                }
+
+                foreach (var subdir in subdirEntries)
+                {
+                    var en = EnumerateFilesOpportunistic(subdir, searchPattern, searchOption);
+                    foreach (var p in en)
+                    {
+                        yield return p;
+                    }
+                }
+            }
+
+            if (searchOption == SearchOption.AllDirectories || searchOption == SearchOption.TopDirectoryOnly)
+            {
+                foreach (var p in Directory.EnumerateFiles(path, searchPattern, SearchOption.TopDirectoryOnly))
+                {
+                    yield return p;
+                }
+            }
+            else
+            {
+                throw new ArgumentException("invalid search option", nameof(searchOption));
+            }
+        }
+    }
+}


### PR DESCRIPTION
The test suite for Gu.Wpf.UiAutomation still passes after this change, but no test case for that one. 

Makes it possible for the tests of Gu.Wpf.PropertyGrid to run under VS test runner though.