### PR TITLE
Add dotnet6.0-windows as supported target

### DIFF
--- a/Gu.Wpf.UiAutomation.Tests/Gu.Wpf.UiAutomation.Tests.csproj
+++ b/Gu.Wpf.UiAutomation.Tests/Gu.Wpf.UiAutomation.Tests.csproj
@@ -1,7 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48</TargetFrameworks>
+    <TargetFrameworks>net48;net6.0-windows</TargetFrameworks>
+	  <UseWpf>true</UseWpf>
+	  <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -14,16 +16,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="PresentationCore" />
-    <Reference Include="UIAutomationClient" />
-    <Reference Include="UIAutomationTypes" />
-    <Reference Include="WindowsBase" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Gu.Analyzers" Version="2.0.2" PrivateAssets="all" />
     <PackageReference Include="IDisposableAnalyzers" Version="4.0.1" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" PrivateAssets="all" />

--- a/Gu.Wpf.UiAutomation.UiTests/Gu.Wpf.UiAutomation.UITests.csproj
+++ b/Gu.Wpf.UiAutomation.UiTests/Gu.Wpf.UiAutomation.UITests.csproj
@@ -1,8 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48</TargetFrameworks>
+    <TargetFrameworks>net48;net6.0-windows</TargetFrameworks>
     <LangVersion>latest</LangVersion>
+	  <UseWpf>true</UseWpf>
+	  <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
   
   <PropertyGroup>
@@ -26,13 +28,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Gu.Wpf.UiAutomation\Gu.Wpf.UiAutomation.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="PresentationCore" />
-    <Reference Include="UIAutomationClient" />
-    <Reference Include="UIAutomationTypes" />
-    <Reference Include="WindowsBase" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Gu.Wpf.UiAutomation.UiTests/Input/MouseTests.cs
+++ b/Gu.Wpf.UiAutomation.UiTests/Input/MouseTests.cs
@@ -5,6 +5,7 @@ namespace Gu.Wpf.UiAutomation.UiTests.Input
     using System.Linq;
     using System.Windows;
     using NUnit.Framework;
+    using Application = Gu.Wpf.UiAutomation.Application;
 
     public class MouseTests
     {

--- a/Gu.Wpf.UiAutomation.UiTests/Input/TouchTests.cs
+++ b/Gu.Wpf.UiAutomation.UiTests/Input/TouchTests.cs
@@ -7,6 +7,7 @@ namespace Gu.Wpf.UiAutomation.UiTests.Input
     using System.Windows;
     using Gu.Wpf.UiAutomation.WindowsAPI;
     using NUnit.Framework;
+    using Application = Gu.Wpf.UiAutomation.Application;
 
     public class TouchTests
     {

--- a/Gu.Wpf.UiAutomation/Gu.Wpf.UiAutomation.csproj
+++ b/Gu.Wpf.UiAutomation/Gu.Wpf.UiAutomation.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net45;net6.0-windows</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
 	  <UseWpf>true</UseWpf>

--- a/Gu.Wpf.UiAutomation/Gu.Wpf.UiAutomation.csproj
+++ b/Gu.Wpf.UiAutomation/Gu.Wpf.UiAutomation.csproj
@@ -1,9 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net45</TargetFrameworks>
+    <TargetFrameworks>net48;net6.0-windows</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
+	  <UseWpf>true</UseWpf>
+	  <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -44,20 +46,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Accessibility" />
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-    <Reference Include="System.Xaml" />
-    <Reference Include="UIAutomationClient" />
-    <Reference Include="UIAutomationTypes" />
-    <Reference Include="WindowsBase" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" PrivateAssets="all" />
     <PackageReference Include="Gu.Analyzers" Version="2.0.2" PrivateAssets="all" />
     <PackageReference Include="IDisposableAnalyzers" Version="4.0.1" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.3" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
     <PackageReference Include="ReflectionAnalyzers" Version="0.3.1" PrivateAssets="all" />

--- a/TestApplications/Netcore3App/Netcore3App.csproj
+++ b/TestApplications/Netcore3App/Netcore3App.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Gu.Analyzers" Version="2.0.2" PrivateAssets="all" />
     <PackageReference Include="IDisposableAnalyzers" Version="4.0.1" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0" PrivateAssets="all" />
     <PackageReference Include="ReflectionAnalyzers" Version="0.3.1" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.261" PrivateAssets="all" />
   </ItemGroup>

--- a/TestApplications/WpfApplication/WpfApplication.csproj
+++ b/TestApplications/WpfApplication/WpfApplication.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Gu.Analyzers" Version="2.0.2" PrivateAssets="all" />
     <PackageReference Include="IDisposableAnalyzers" Version="4.0.1" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0" PrivateAssets="all" />
     <PackageReference Include="ReflectionAnalyzers" Version="0.3.1" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.261" PrivateAssets="all" />
   </ItemGroup>


### PR DESCRIPTION
- Add net6.0-windows as supported target
- Update deprecated Microsoft.CodeAnalysis.FxCopAnalyzers to Microsoft.CodeAnalysis.NetAnalyzers