### PR TITLE
Fix uncaught exception in Application.TryAttach

### DIFF
--- a/Gu.Wpf.UiAutomation/Application.cs
+++ b/Gu.Wpf.UiAutomation/Application.cs
@@ -206,7 +206,18 @@ namespace Gu.Wpf.UiAutomation
             }
 
             var running = Process.GetProcessesByName(Path.GetFileNameWithoutExtension(exeFileName))
-                                 .FirstOrDefault(x => x.StartInfo.Arguments == processStartInfo.Arguments);
+                                 .FirstOrDefault(x =>
+                                 {
+                                     try
+                                     {
+                                         return x.StartInfo.Arguments == processStartInfo.Arguments;
+                                     }
+                                     catch (InvalidOperationException)
+                                     {
+                                         // This can happen for processes that we didn't start
+                                         return false;
+                                     }
+                                 });
 
             if (running is { })
             {


### PR DESCRIPTION
Fixes #184

Catch the exception in TryAttach so it behaves more like a "Try" method.

This code is only reached when the process we're looking for is not part of the Launched collection, so this change won't affect the main path of application re-use.